### PR TITLE
chore: rename Claude Code plugin identity obsidian-mcp → obsidi-mcp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "obsidian-mcp",
+  "name": "obsidi-mcp",
   "owner": {
     "name": "Cameron Sjo",
     "github": "cameronsjo"
   },
   "plugins": [
     {
-      "name": "obsidian-mcp",
+      "name": "obsidi-mcp",
       "source": "./.claude-plugin",
       "description": "Obsidian plugin exposing 28+ vault tools via MCP server"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "obsidian-mcp",
+  "name": "obsidi-mcp",
   "description": "Obsidian plugin exposing 28+ vault tools via MCP server",
   "author": {
     "name": "cameronsjo"

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-mcp
+name: obsidi-mcp:onboard
 description: "Get started with obsidi-mcp — what it is, how to set it up, and how to use it"
 ---
 

--- a/src/obsidianTools.ts
+++ b/src/obsidianTools.ts
@@ -4,7 +4,7 @@ import type { ToolDefinition, ToolExecutionContext } from './types';
 
 /**
  * Duck-type interfaces for RAG service compatibility.
- * obsidian-mcp ships without RAG — these allow compilation.
+ * obsidi-mcp ships without RAG — these allow compilation.
  * When obsidi-claude registers as a tool provider, its RAG-enhanced tools override these.
  */
 


### PR DESCRIPTION
Completes the plugin's rename to `obsidi-mcp`. The Obsidian `manifest.json` id, `package.json` name, README, and the onboard skill's body already used `obsidi-mcp` — only the **Claude Code plugin identity** files lagged behind at the stale `obsidian-mcp`.

## Changes
- `.claude-plugin/plugin.json` — `name` → `obsidi-mcp`
- `.claude-plugin/marketplace.json` — self-marketplace name + plugin entry name → `obsidi-mcp`
- `skills/onboard/SKILL.md` — frontmatter `name` → `obsidi-mcp:onboard` (the convention-conforming `namespace:directory` form; the prior `obsidian-mcp` was a latent name/directory mismatch)
- `src/obsidianTools.ts` — a stale prose comment

No functional change — the Obsidian plugin `id`, npm package, and all runtime code are untouched (the plugin was already looked up as `obsidi-mcp` at runtime).

## Why
The companion marketplace absorbs this plugin into `workbench` under the name `obsidi-mcp` (cameronsjo/workbench#44). A marketplace entry's name must match the plugin's declared name, so this finishes the rename on the plugin side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)