### PR TITLE
fix(skills): strip the plugin prefix from the frontmatter name

### DIFF
--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidi-mcp:onboard
+name: onboard
 description: "Get started with obsidi-mcp — what it is, how to set it up, and how to use it"
 ---
 


### PR DESCRIPTION
Claude Code **2.1.216** fixed plugin skills with a `name` frontmatter field losing their plugin prefix in slash-command autocomplete — which means Claude Code now prepends the prefix itself. A declared `name: obsidi-mcp:onboard` therefore renders as `/obsidi-mcp:obsidi-mcp:onboard`.

The declared name must be the bare skill directory. **2.1.218** additionally made agent markdown reject names containing `:`, reserving the character for plugin namespacing, so the direction is settled rather than in flight.

One line changed. The invocation id is unaffected — only what the slash menu renders.

Found by auditing all 29 plugins registered in the workbench marketplace, not just the ones with a local checkout; this repo and `homebridge-dev` were the two outside the cadence family still on the old convention. Companion PRs: cameronsjo/cadence#545 (129 skills, plus a reversible sweep script), cameronsjo/cadence-lab#12 (12), cameronsjo/auditing-claude-md#5 (1), cameronsjo/homebridge-dev#1 (1).